### PR TITLE
add: Support hex notation by 0xabcd when converting to bignum values

### DIFF
--- a/src/bignum.c
+++ b/src/bignum.c
@@ -83,9 +83,9 @@ Datum pgx_bignum_in(PG_FUNCTION_ARGS) {
 
     // convert to bignum
     bn = BN_new();
-    len = BN_dec2bn(&bn, txt);
+    len = BN_asc2bn(&bn, txt);
 
-    if (strlen(txt) != len) {
+    if (!len) {
         elog(ERROR, "length mismatch - non-numeric values?");
         PG_RETURN_NULL();
     }


### PR DESCRIPTION
As some if not most big numbers are usually given in hex it's nice to have a direct way of importing/converting them from string. Given that parsing hex to binary is even much faster than base conversion from base 10 to base 256 (for binary) it's highly recommended to prefer hex input for performance.

For output both formats have their advantages ...
