### PR TITLE
Fix build system, and add input from hex.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: sql/$(EXTENSION)--$(EXTVERSION).sql
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
-DATA = $(wildcard sql/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
+DATA = $(wildcard sql/*--*.sql)
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
 endif
 

--- a/sql/bignum.sql
+++ b/sql/bignum.sql
@@ -25,9 +25,14 @@
 --
 CREATE TYPE bignum;
 
-CREATE OR REPLACE FUNCTION bn_in(cstring)
+CREATE OR REPLACE FUNCTION bn_in_dec(cstring)
 RETURNS bignum
-AS 'bignum', 'pgx_bignum_in'
+AS 'bignum', 'pgx_bignum_in_dec'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION bn_in_hex(cstring)
+RETURNS bignum
+AS 'bignum', 'pgx_bignum_in_hex'
 LANGUAGE C IMMUTABLE STRICT;
 
 CREATE OR REPLACE FUNCTION bn_out(bignum)
@@ -36,7 +41,7 @@ AS 'bignum', 'pgx_bignum_out'
 LANGUAGE C IMMUTABLE STRICT;
 
 CREATE TYPE bignum (
-    INPUT   = bn_in,
+    INPUT   = bn_in_dec,
     OUTPUT  = bn_out
 );
 

--- a/sql/bignum.sql
+++ b/sql/bignum.sql
@@ -40,6 +40,10 @@ RETURNS CSTRING
 AS 'bignum', 'pgx_bignum_out'
 LANGUAGE C IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION bn_out_hex(bignum)
+RETURNS CSTRING AS 'bignum', 'pgx_bignum_out_hex'
+LANGUAGE C IMMUTABLE STRICT;
+
 CREATE OR REPLACE FUNCTION bn_in(cstring)
 RETURNS bignum
 AS 'bignum', 'pgx_bignum_in_asc'

--- a/sql/bignum.sql
+++ b/sql/bignum.sql
@@ -40,8 +40,13 @@ RETURNS CSTRING
 AS 'bignum', 'pgx_bignum_out'
 LANGUAGE C IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION bn_in(cstring)
+RETURNS bignum
+AS 'bignum', 'pgx_bignum_in_asc'
+LANGUAGE C IMMUTABLE STRICT;
+
 CREATE TYPE bignum (
-    INPUT   = bn_in_dec,
+    INPUT   = bn_in,
     OUTPUT  = bn_out
 );
 

--- a/src/bignum.c
+++ b/src/bignum.c
@@ -67,6 +67,33 @@ PG_MODULE_MAGIC;
 /**
  * Read from cstring
  */
+
+PG_FUNCTION_INFO_V1(pgx_bignum_in_asc);
+
+Datum pgx_bignum_in_asc(PG_FUNCTION_ARGS) {
+    char *txt;
+    bytea *results;
+    BIGNUM *bn;
+
+    // check for null input
+    txt = PG_GETARG_CSTRING(0);
+    if (strlen(txt) == 0) {
+        PG_RETURN_NULL();
+    }
+
+    // convert to bignum
+    bn = BN_new();
+    BN_asc2bn(&bn, txt);
+
+    // write to binary format
+    results = bignum_to_bytea(bn);
+    BN_free(bn);
+
+    // return bytea
+    PG_RETURN_BYTEA_P(results);
+}
+
+
 PG_FUNCTION_INFO_V1(pgx_bignum_in_dec);
 
 Datum pgx_bignum_in_dec(PG_FUNCTION_ARGS) {

--- a/src/bignum.c
+++ b/src/bignum.c
@@ -67,9 +67,9 @@ PG_MODULE_MAGIC;
 /**
  * Read from cstring
  */
-PG_FUNCTION_INFO_V1(pgx_bignum_in);
+PG_FUNCTION_INFO_V1(pgx_bignum_in_dec);
 
-Datum pgx_bignum_in(PG_FUNCTION_ARGS) {
+Datum pgx_bignum_in_dec(PG_FUNCTION_ARGS) {
     char *txt;
     int len;
     bytea *results;
@@ -77,7 +77,7 @@ Datum pgx_bignum_in(PG_FUNCTION_ARGS) {
 
     // check for null input
     txt = PG_GETARG_CSTRING(0);
-    if (txt == NULL || strlen(txt) == 0) {
+    if (strlen(txt) == 0) {
         PG_RETURN_NULL();
     }
 
@@ -87,8 +87,34 @@ Datum pgx_bignum_in(PG_FUNCTION_ARGS) {
 
     if (strlen(txt) != len) {
         elog(ERROR, "length mismatch - non-numeric values?");
+        BN_free(bn);
         PG_RETURN_NULL();
     }
+
+    // write to binary format
+    results = bignum_to_bytea(bn);
+    BN_free(bn);
+
+    // return bytea
+    PG_RETURN_BYTEA_P(results);
+}
+
+PG_FUNCTION_INFO_V1(pgx_bignum_in_hex);
+
+Datum pgx_bignum_in_hex(PG_FUNCTION_ARGS) {
+    char *txt;
+    bytea *results;
+    BIGNUM *bn;
+
+    // check for null input
+    txt = PG_GETARG_CSTRING(0);
+    if (strlen(txt) == 0) {
+        PG_RETURN_NULL();
+    }
+
+    // convert to bignum
+    bn = BN_new();
+    BN_hex2bn(&bn, txt);
 
     // write to binary format
     results = bignum_to_bytea(bn);

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -19,6 +19,7 @@ Datum pgx_bignum_in_asc(PG_FUNCTION_ARGS);
 Datum pgx_bignum_in_hex(PG_FUNCTION_ARGS);
 Datum pgx_bignum_in_dec(PG_FUNCTION_ARGS);
 Datum pgx_bignum_out(PG_FUNCTION_ARGS);
+Datum pgx_bignum_out_hex(PG_FUNCTION_ARGS);
 
 Datum BnGetDatum(BIGNUM *bn);
 

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -15,7 +15,8 @@ BIGNUM * bytea_to_bignum(bytea *raw);
 bytea * bignum_to_bytea(BIGNUM *bn);
 
 // big numbers
-Datum pgx_bignum_in(PG_FUNCTION_ARGS);
+Datum pgx_bignum_in_hex(PG_FUNCTION_ARGS);
+Datum pgx_bignum_in_dec(PG_FUNCTION_ARGS);
 Datum pgx_bignum_out(PG_FUNCTION_ARGS);
 
 Datum BnGetDatum(BIGNUM *bn);

--- a/src/bignum.h
+++ b/src/bignum.h
@@ -15,6 +15,7 @@ BIGNUM * bytea_to_bignum(bytea *raw);
 bytea * bignum_to_bytea(BIGNUM *bn);
 
 // big numbers
+Datum pgx_bignum_in_asc(PG_FUNCTION_ARGS);
 Datum pgx_bignum_in_hex(PG_FUNCTION_ARGS);
 Datum pgx_bignum_in_dec(PG_FUNCTION_ARGS);
 Datum pgx_bignum_out(PG_FUNCTION_ARGS);


### PR DESCRIPTION
* The build system previously was broke, files were attempting to be
  copied twice fouling make. See issue #2 on github.

* We didn't currently have a method of converting hex to bignum, added.

* Also fixed freeing in the event of length mismatch, believe this was a
  memory leak.

* Changed the default previously for _in which was cstring->bignum but dec specific to provide for hex if prefix with 0x was detected by using asc2bn internally. Basically a copy of @BenBE's  https://github.com/beargiles/pg-bignum/pull/1